### PR TITLE
add vandalism detection script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ LC_MESSAGES/
 .idea
 **/*.pyc
 /build/
+__pycache__/

--- a/llm_vandalism_detection/README.md
+++ b/llm_vandalism_detection/README.md
@@ -1,0 +1,47 @@
+## translation string vandalism detection script
+
+The `llm_vandalism_detection.py` script is intended to detect vandalism in the Electrum translations.
+
+It can be run against a local Ollama model or against an OpenAI API compatible LLM API provider.
+
+gemini-3-flash-preview seems to work well (it passes the unittests) and costs roughly ~0.02 usd cent per translation (prompt).
+
+Usage Example:
+```bash
+$ ./llm_vandalism_detection/llm_vandalism_detection.py --api openai --openai-url https://api.ppq.ai --openai-key sk-ABCD --model google/gemini-3-flash-preview --locale-dir locale/eo_UY
+SPAM: Close -> Fermi
+Report written: vandalism_reports/vandalism_report_eo_UY.json
+
+Scanned: 1 locales
+Skipped: 0 locales (reports already exist)
+Total spam found: 1
+
+Summary report written to: vandalism_reports/vandalism_report_summary.txt
+Summary JSON written to: vandalism_reports/vandalism_report_summary.json
+
+$ ls vandalism_reports
+vandalism_report_eo_UY.json  vandalism_report_summary.json  vandalism_report_summary.txt
+
+$ cat cat vandalism_reports/vandalism_report_eo_UY.json 
+{
+  "generated": "2026-02-17T16:08:55.289813",
+  "locale": "eo_UY",
+  "total_spam": 1,
+  "entries": [
+    {
+      "locale": "eo_UY",
+      "original_str": "Close",
+      "translation": "Fermi"
+    }
+  ]
+}
+```
+
+### Unittests
+
+The unittests act as some form of benchmark to check if a LLM is suitable to run this check.
+
+Running the unittests:
+```bash
+API_BACKEND=openai OPENAI_BASE_URL=https://api.ppq.ai OPENAI_MODEL=google/gemini-3-flash-preview OPENAI_API_KEY=ABC python3 -m unittest test_vandalism_detection.py
+```

--- a/llm_vandalism_detection/llm_vandalism_detection.py
+++ b/llm_vandalism_detection/llm_vandalism_detection.py
@@ -1,0 +1,456 @@
+#!/usr/bin/env python3
+"""
+Vandalism detection for translation files using LLM (OpenAI-compatible API).
+
+Usage:
+  ./llm_vandalism_detection.py --openai-url https://api.ppq.ai --openai-key YOUR_KEY --model google/gemini-3-flash-preview --locale-dir locale
+"""
+
+import asyncio
+import json
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+try:
+    import polib
+except ImportError as e:
+    sys.exit(f"Error: {str(e)}. Try 'python3 -m pip install --user polib' (or 'python3-polib' from Debian)")
+
+try:
+    import aiohttp
+except ImportError as e:
+    sys.exit(f"Error: {str(e)}. Try 'python3 -m pip install --user aiohttp' (or 'python3-aiohttp' from Debian)")
+
+
+
+# Concurrency and retry configuration
+CONCURRENCY_DEFAULT = 50
+RETRY_DELAY_DEFAULT = 2.0  # seconds between retries
+
+# OpenAI-compatible API configuration
+OPENAI_BASE_URL_DEFAULT = "https://api.ppq.ai"
+OPENAI_MODEL_DEFAULT = "google/gemini-3-flash-preview"  # this passes the unittest, cheaper than haiku, ~0.02 ct/req
+# OPENAI_MODEL_DEFAULT = "claude-haiku-4.5"  # this passes the unittest, seems to work well, costs ~0.06 ct/req (ppq.ai)
+
+
+PROMPT_TEMPLATE = """
+You are a binary classifier for translation quality control.
+
+Input format:
+original_str: <original English string>
+translation_str: <translated string>
+target_language: <target language code>
+
+Task:
+Determine whether translation_str is a plausible translation of original_str into the target language.
+
+Classification: Genuine or Spam
+
+Genuine — translation_str is a plausible rendering of original_str in the target language. This includes:
+- Natural/idiomatic translations that do not match word-for-word.
+    - Translations that leave technical terms, brand names, or proper nouns untranslated.
+- Translations that are significantly shorter or longer than original_str due to language characteristics.
+- Partial translations where most meaning is preserved.
+- Strings in scripts or character sets consistent with the target language.
+- Strings that differ in formality, register, or phrasing but convey the same intent.
+
+Spam — translation_str has no plausible relationship to original_str. Clear indicators:
+- Completely unrelated topic (advertisements, political slogans, solicitations).
+- Cryptocurrency addresses, any URLs, or contact information injected where none exists in original_str.
+- Any URL appearing in translation_str that does not appear in original_str, even if it is seemingly related to Electrum.
+- Obvious trolling, joke replacements, or intentionally offensive substitutions.
+- Random character sequences with no linguistic structure.
+- Empty string when original_str is non-empty.
+- Text in a language entirely inconsistent with the target_language code.
+
+Decision policy:
+- Default to Genuine unless there is strong positive evidence of spam.
+- Do NOT flag a string as Spam merely because you are uncertain about the language or translation accuracy.
+- A poor-quality or inaccurate translation is still Genuine if it appears to be a good-faith attempt.
+- When in doubt, output Spam.
+
+Domain context:
+- These are UI strings for a Bitcoin wallet application (Electrum Wallet).
+- Placeholders (e.g., %1, %s, {{}}, ...), Qt markup (e.g., &, <b>, </b>), and technical tokens are expected and must not trigger Spam.
+- References to bitcoin, transactions, wallets, keys, addresses, and blockchain terminology are expected domain vocabulary, not spam indicators.
+
+Output requirements:
+- Output exactly one token: Genuine or Spam
+- No punctuation, explanation, or extra text.
+
+Input:
+
+original_str: {msgid}
+translation_str: {msgstr}
+target_language: {lang}
+"""
+
+
+
+def get_openai_url():
+    return os.environ.get("OPENAI_BASE_URL", OPENAI_BASE_URL_DEFAULT)
+
+
+def get_openai_model():
+    return os.environ.get("OPENAI_MODEL", OPENAI_MODEL_DEFAULT)
+
+
+def get_openai_api_key():
+    return os.environ.get("OPENAI_API_KEY", "")
+
+
+def get_concurrency():
+    return int(os.environ.get("CONCURRENCY", CONCURRENCY_DEFAULT))
+
+
+def get_retry_delay():
+    return float(os.environ.get("RETRY_DELAY", RETRY_DELAY_DEFAULT))
+
+
+def parse_po_file(filepath: str) -> list[tuple[str, str]]:
+    """
+    Parse a .po file and extract msgid/msgstr pairs.
+    Returns list of (msgid, msgstr) tuples.
+    """
+    po = polib.pofile(filepath)
+    return [(entry.msgid, entry.msgstr) for entry in po if entry.msgid]
+
+
+async def call_openai_async(session: aiohttp.ClientSession, prompt: str) -> str:
+    """
+    Call an OpenAI-compatible API asynchronously using aiohttp.
+    Retries indefinitely on failure with a delay between attempts.
+    """
+    url = f"{get_openai_url()}/chat/completions"
+    api_key = get_openai_api_key()
+    retry_delay = get_retry_delay()
+
+    payload = {
+        "model": get_openai_model(),
+        "messages": [
+            {"role": "user", "content": prompt}
+        ],
+    }
+
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    while True:
+        try:
+            async with session.post(url, json=payload, headers=headers, timeout=aiohttp.ClientTimeout(total=60)) as response:
+                if response.status != 200:
+                    body = await response.text()
+                    raise RuntimeError(f"HTTP {response.status}: {body}")
+                result = await response.json()
+                response = result["choices"][0]["message"]["content"].strip().lower()
+                assert response in ("genuine", "spam"), f"invalid response: {response}"
+                return response
+        except Exception as e:
+            print(f"Request failed ({e}), retrying in {retry_delay}s...", file=sys.stderr)
+            await asyncio.sleep(retry_delay)
+
+
+
+async def classify_translation_async(
+    session: aiohttp.ClientSession,
+    semaphore: asyncio.Semaphore,
+    msgid: str,
+    msgstr: str,
+    lang: str,
+) -> str:
+    """
+    Classify a translation as Genuine or Spam using the OpenAI-compatible API asynchronously.
+    """
+    prompt = PROMPT_TEMPLATE.format(msgid=msgid, msgstr=msgstr, lang=lang)
+    async with semaphore:
+        response = await call_openai_async(session, prompt)
+    if "genuine" in response:
+        return "Genuine"
+    return "Spam"
+
+
+def get_report_path(output_dir: Path, locale_name: str) -> Path:
+    """
+    Get the report file path for a specific locale.
+    """
+    return output_dir / f"vandalism_report_{locale_name}.json"
+
+
+def report_exists(output_dir: Path, locale_name: str) -> bool:
+    """
+    Check if a report already exists for the given locale.
+    """
+    return get_report_path(output_dir, locale_name).exists()
+
+
+async def scan_po_file_async(
+    session: aiohttp.ClientSession,
+    semaphore: asyncio.Semaphore,
+    po_file: Path,
+    locale_name: str,
+) -> list[dict]:
+    """
+    Scan a single .po file using concurrent async OpenAI API requests.
+    Returns list of spam entries.
+    """
+    entries = parse_po_file(str(po_file))
+    translated = [(mid, mst) for mid, mst in entries if mst]
+
+    async def _check(msgid: str, msgstr: str):
+        classification = await classify_translation_async(session, semaphore, msgid, msgstr, locale_name)
+        if classification == "Spam":
+            print(f"SPAM: {msgid} -> {msgstr}")
+            return {"locale": locale_name, "original_str": msgid, "translation": msgstr}
+        return None
+
+    results = await asyncio.gather(*[_check(mid, mst) for mid, mst in translated])
+    return [r for r in results if r is not None]
+
+
+def write_locale_report(spam_entries: list[dict], output_dir: Path, locale_name: str):
+    """
+    Write spam entries for a single locale to a report file.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    json_path = get_report_path(output_dir, locale_name)
+
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "generated": datetime.now().isoformat(),
+                "locale": locale_name,
+                "total_spam": len(spam_entries),
+                "entries": spam_entries,
+            },
+            f,
+            indent=2,
+            ensure_ascii=False,
+        )
+
+    print(f"Report written: {json_path}")
+
+
+
+async def scan_locale_directory_async(locale_dir: str, output_dir: str, force: bool = False) -> dict:
+    """
+    Scan all .po files using concurrent async OpenAI API requests.
+    Skips locales that already have reports unless force=True.
+    Returns dict with scan statistics.
+    """
+    locale_path = Path(locale_dir)
+    output_path = Path(output_dir)
+    concurrency = get_concurrency()
+    semaphore = asyncio.Semaphore(concurrency)
+
+    stats = {
+        "scanned": 0,
+        "skipped": 0,
+        "total_spam": 0,
+    }
+
+    locales = {}
+    for po_file in sorted(locale_path.rglob("*.po")):
+        locale_name = po_file.parent.name
+        if locale_name not in locales:
+            locales[locale_name] = []
+        locales[locale_name].append(po_file)
+
+    async with aiohttp.ClientSession() as session:
+        for locale_name in sorted(locales.keys()):
+            if not force and report_exists(output_path, locale_name):
+                print(f"Skipping {locale_name} (report exists)")
+                stats["skipped"] += 1
+                continue
+
+            print(f"Scanning: {locale_name}")
+            locale_spam = []
+
+            for po_file in locales[locale_name]:
+                spam_entries = await scan_po_file_async(session, semaphore, po_file, locale_name)
+                locale_spam.extend(spam_entries)
+
+            write_locale_report(locale_spam, output_path, locale_name)
+            stats["scanned"] += 1
+            stats["total_spam"] += len(locale_spam)
+
+    return stats
+
+
+def write_summary_report(output_dir: str):
+    """
+    Generate a summary report from all individual locale reports.
+    """
+    output_path = Path(output_dir)
+    all_entries = []
+
+    for report_file in sorted(output_path.glob("vandalism_report_*.json")):
+        with open(report_file, "r", encoding="utf-8") as f:
+            data = json.load(f)
+            all_entries.extend(data.get("entries", []))
+
+    # Write combined text report
+    txt_path = output_path / "vandalism_report_summary.txt"
+    with open(txt_path, "w", encoding="utf-8") as f:
+        f.write("=" * 80 + "\n")
+        f.write("VANDALISM DETECTION SUMMARY REPORT\n")
+        f.write(f"Generated: {datetime.now().isoformat()}\n")
+        f.write(f"Total spam entries detected: {len(all_entries)}\n")
+        f.write("=" * 80 + "\n\n")
+
+        # Group by locale
+        by_locale = {}
+        for entry in all_entries:
+            locale = entry["locale"]
+            if locale not in by_locale:
+                by_locale[locale] = []
+            by_locale[locale].append(entry)
+
+        for locale in sorted(by_locale.keys()):
+            entries = by_locale[locale]
+            f.write(f"\n{'─' * 40}\n")
+            f.write(f"LOCALE: {locale} ({len(entries)} entries)\n")
+            f.write(f"{'─' * 40}\n\n")
+
+            for entry in entries:
+                f.write(f"Original: {entry['original_str']}\n")
+                f.write(f"Translation: {entry['translation']}\n")
+                f.write("\n")
+
+    # Write combined JSON report
+    json_path = output_path / "vandalism_report_summary.json"
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "generated": datetime.now().isoformat(),
+                "total_spam": len(all_entries),
+                "entries": all_entries,
+            },
+            f,
+            indent=2,
+            ensure_ascii=False,
+        )
+
+    print(f"\nSummary report written to: {txt_path}")
+    print(f"Summary JSON written to: {json_path}")
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Detect vandalized translations using LLM"
+    )
+    parser.add_argument(
+        "--locale-dir",
+        default="locale",
+        help="Path to locale directory (default: locale)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="vandalism_reports",
+        help="Output directory for reports (default: vandalism_reports)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-scan locales even if report exists",
+    )
+    parser.add_argument(
+        "--count",
+        action="store_true",
+        help="Count translatable strings per locale and print totals (no LLM calls)",
+    )
+    parser.add_argument(
+        "--summary-only",
+        action="store_true",
+        help="Only generate summary report from existing locale reports",
+    )
+    parser.add_argument(
+        "--openai-url",
+        default=None,
+        help=f"OpenAI-compatible API base URL (default: {OPENAI_BASE_URL_DEFAULT})",
+    )
+    parser.add_argument(
+        "--openai-key",
+        default=None,
+        help="OpenAI API key (can also use OPENAI_API_KEY env var)",
+    )
+    parser.add_argument(
+        "--model",
+        default=None,
+        help=f"Model to use (default depends on API backend)",
+    )
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=None,
+        help=f"Max concurrent requests for OpenAI backend (default: {CONCURRENCY_DEFAULT})",
+    )
+    parser.add_argument(
+        "--retry-delay",
+        type=float,
+        default=None,
+        help=f"Seconds between retries on failed requests (default: {RETRY_DELAY_DEFAULT})",
+    )
+    args = parser.parse_args()
+
+    if args.openai_url:
+        os.environ["OPENAI_BASE_URL"] = args.openai_url
+    if args.openai_key:
+        os.environ["OPENAI_API_KEY"] = args.openai_key
+    if args.model:
+        os.environ["OPENAI_MODEL"] = args.model
+    if args.concurrency is not None:
+        os.environ["CONCURRENCY"] = str(args.concurrency)
+    if args.retry_delay is not None:
+        os.environ["RETRY_DELAY"] = str(args.retry_delay)
+
+    if args.count:
+        if not os.path.isdir(args.locale_dir):
+            print(f"Error: Locale directory not found: {args.locale_dir}")
+            return 1
+        locale_path = Path(args.locale_dir)
+        total = 0
+        for po_file in sorted(locale_path.rglob("*.po")):
+            locale_name = po_file.parent.name
+            entries = parse_po_file(str(po_file))
+            translated = [(mid, mst) for mid, mst in entries if mst]
+            count = len(translated)
+            total += count
+            print(f"{locale_name}: {count} strings")
+        print(f"\nTotal: {total} strings ({total} LLM requests)")
+        return 0
+
+    if args.summary_only:
+        write_summary_report(args.output_dir)
+        return 0
+
+    if not os.path.isdir(args.locale_dir):
+        print(f"Error: Locale directory not found: {args.locale_dir}")
+        return 1
+
+    print(f"API: OpenAI-compatible (async, concurrency={get_concurrency()})")
+    print(f"URL: {get_openai_url()}")
+    print(f"Model: {get_openai_model()}")
+    print(f"Locale directory: {args.locale_dir}")
+    print(f"Output directory: {args.output_dir}")
+    print(f"Force re-scan: {args.force}")
+    print()
+
+    stats = asyncio.run(scan_locale_directory_async(args.locale_dir, args.output_dir, args.force))
+
+    print()
+    print(f"Scanned: {stats['scanned']} locales")
+    print(f"Skipped: {stats['skipped']} locales (reports already exist)")
+    print(f"Total spam found: {stats['total_spam']}")
+
+    write_summary_report(args.output_dir)
+
+    return 0
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_ar_SA.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_ar_SA.json
@@ -1,0 +1,32 @@
+{
+  "generated": "2026-02-18T17:27:14.345258",
+  "locale": "ar_SA",
+  "total_spam": 5,
+  "entries": [
+    {
+      "locale": "ar_SA",
+      "original_str": "- an arbitrary on-chain script, e.g.:",
+      "translation": "مشغول"
+    },
+    {
+      "locale": "ar_SA",
+      "original_str": "Add to coin control",
+      "translation": "Add to coin control"
+    },
+    {
+      "locale": "ar_SA",
+      "original_str": "Cannot start QR scanner, no usable camera found.",
+      "translation": "غير مسموح لك في هذا الجهاز باستخدام كير"
+    },
+    {
+      "locale": "ar_SA",
+      "original_str": "Cannot start QR scanner: initialization failed.",
+      "translation": "غير مسموح لك بالقيام  بكير تلف في البيانات"
+    },
+    {
+      "locale": "ar_SA",
+      "original_str": "Startup times are instant because it operates in conjunction with high-performance servers that handle the most complicated parts of the Bitcoin system.",
+      "translation": "Startup times are instant because it operates in conjunction with high-performance servers that handle the most complicated parts of the Bitcoin system."
+    }
+  ]
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_az_AZ.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_az_AZ.json
@@ -1,0 +1,12 @@
+{
+  "generated": "2026-02-18T18:06:48.065356",
+  "locale": "az_AZ",
+  "total_spam": 1,
+  "entries": [
+    {
+      "locale": "az_AZ",
+      "original_str": "Details",
+      "translation": "Detallar"
+    }
+  ]
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_be_BY.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_be_BY.json
@@ -1,0 +1,6 @@
+{
+  "generated": "2026-02-18T18:16:49.972523",
+  "locale": "be_BY",
+  "total_spam": 0,
+  "entries": []
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_bg_BG.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_bg_BG.json
@@ -1,0 +1,6 @@
+{
+  "generated": "2026-02-18T19:04:40.257102",
+  "locale": "bg_BG",
+  "total_spam": 0,
+  "entries": []
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_bn_BD.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_bn_BD.json
@@ -1,0 +1,6 @@
+{
+  "generated": "2026-02-18T19:04:56.775004",
+  "locale": "bn_BD",
+  "total_spam": 0,
+  "entries": []
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_cs_CZ.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_cs_CZ.json
@@ -1,0 +1,12 @@
+{
+  "generated": "2026-02-18T20:33:39.585934",
+  "locale": "cs_CZ",
+  "total_spam": 1,
+  "entries": [
+    {
+      "locale": "cs_CZ",
+      "original_str": "&Pay to many",
+      "translation": "&Hromadná platba"
+    }
+  ]
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_da_DK.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_da_DK.json
@@ -1,0 +1,22 @@
+{
+  "generated": "2026-02-18T20:45:44.735329",
+  "locale": "da_DK",
+  "total_spam": 3,
+  "entries": [
+    {
+      "locale": "da_DK",
+      "original_str": "Save",
+      "translation": "Gem"
+    },
+    {
+      "locale": "da_DK",
+      "original_str": "Save",
+      "translation": "Gem"
+    },
+    {
+      "locale": "da_DK",
+      "original_str": "Save",
+      "translation": "Gem"
+    }
+  ]
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_de_DE.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_de_DE.json
@@ -1,0 +1,17 @@
+{
+  "generated": "2026-02-18T22:02:22.015620",
+  "locale": "de_DE",
+  "total_spam": 2,
+  "entries": [
+    {
+      "locale": "de_DE",
+      "original_str": "Terms of Use",
+      "translation": "Nutzungsbedingungen"
+    },
+    {
+      "locale": "de_DE",
+      "original_str": "Server settings",
+      "translation": "Servereinstellungen"
+    }
+  ]
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_el_GR.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_el_GR.json
@@ -1,0 +1,12 @@
+{
+  "generated": "2026-02-18T22:18:42.727819",
+  "locale": "el_GR",
+  "total_spam": 1,
+  "entries": [
+    {
+      "locale": "el_GR",
+      "original_str": "Exit Electrum",
+      "translation": "Έξοδος από το Electrum"
+    }
+  ]
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_eo_UY.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_eo_UY.json
@@ -1,0 +1,12 @@
+{
+  "generated": "2026-02-18T22:20:24.484610",
+  "locale": "eo_UY",
+  "total_spam": 1,
+  "entries": [
+    {
+      "locale": "eo_UY",
+      "original_str": "Close",
+      "translation": "Fermi"
+    }
+  ]
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_es_ES.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_es_ES.json
@@ -1,0 +1,97 @@
+{
+  "generated": "2026-02-18T23:01:14.597480",
+  "locale": "es_ES",
+  "total_spam": 18,
+  "entries": [
+    {
+      "locale": "es_ES",
+      "original_str": "A CPFP is a transaction that sends an unconfirmed output back to yourself, with a high fee. The goal is to have miners confirm the parent transaction in order to get the fee attached to the child transaction.",
+      "translation": "A CPFP is a transaction that sends an unconfirmed output back to yourself, with a high fee. The goal is to have miners confirm the parent transaction in order to get the fee attached to the child transaction"
+    },
+    {
+      "locale": "es_ES",
+      "original_str": "Cannot determine dynamic fees, not connected",
+      "translation": "Key: Cannot determine dynamic fees, not connected\\n#: electrum/gui/qml/qetxfinalizer.py:431\\nFile: messages.pot"
+    },
+    {
+      "locale": "es_ES",
+      "original_str": "Cannot pay less than the amount specified in the invoice",
+      "translation": "Cannot pay less than the amount specified in the invoice"
+    },
+    {
+      "locale": "es_ES",
+      "original_str": "Error parsing Lightning invoice",
+      "translation": "Error al analizar la factura Lightning\\n SOLICITUD DE CONTEXTO"
+    },
+    {
+      "locale": "es_ES",
+      "original_str": "Fees are paid by the sender.",
+      "translation": "Las tarifas las paga el remitente.\\n SOLICITUD DE CONTEXTO"
+    },
+    {
+      "locale": "es_ES",
+      "original_str": "Integers weights can also be used in conjunction with '!', e.g. set one amount to '2!' and another to '3!' to split your coins 40-60.",
+      "translation": "Los pesos enteros también se pueden usar junto con '!', P. Ej.  establezca una cantidad en '2!'  y otro a '¡3!'  para dividir sus monedas 40-60.\\n SOLICITUD DE CONTEXTO"
+    },
+    {
+      "locale": "es_ES",
+      "original_str": "Invoice has unknown status",
+      "translation": "Key: Invoice has unknown status\\n#: electrum/gui/qml/qeinvoice.py:295 electrum/gui/qml/qeinvoice.py:312\\nFile: messages.pot"
+    },
+    {
+      "locale": "es_ES",
+      "original_str": "Raw",
+      "translation": "Proporciona soporte para la cartera de hardware Safe-T mini"
+    },
+    {
+      "locale": "es_ES",
+      "original_str": "Rebalance your channels in order to increase your sending or receiving capacity",
+      "translation": "Rebalance your channels in order to increase your sending or receiving capacity"
+    },
+    {
+      "locale": "es_ES",
+      "original_str": "The platform QR detection library is not available.",
+      "translation": "The platform QR detection library is not available."
+    },
+    {
+      "locale": "es_ES",
+      "original_str": "There are still channels that are not fully closed",
+      "translation": "There are still channels that are not fully closed"
+    },
+    {
+      "locale": "es_ES",
+      "original_str": "There are still coins present in this wallet. Really delete?",
+      "translation": "There are still coins present in this wallet. Really delete?"
+    },
+    {
+      "locale": "es_ES",
+      "original_str": "There are still unpaid requests. Really delete?",
+      "translation": "There are still unpaid requests. Really delete?"
+    },
+    {
+      "locale": "es_ES",
+      "original_str": "This is a channel backup.",
+      "translation": "This is a channel backup."
+    },
+    {
+      "locale": "es_ES",
+      "original_str": "You can use it to request a force close.",
+      "translation": "You can use it to request a force close."
+    },
+    {
+      "locale": "es_ES",
+      "original_str": "You will be able to pay once the swap is confirmed.",
+      "translation": "You will be able to pay once the swap is confirmed."
+    },
+    {
+      "locale": "es_ES",
+      "original_str": "A CPFP is a transaction that sends an unconfirmed output back to yourself, with a high fee. The goal is to have miners confirm the parent transaction in order to get the fee attached to the child transaction.",
+      "translation": "A CPFP is a transaction that sends an unconfirmed output back to yourself, with a high fee. The goal is to have miners confirm the parent transaction in order to get the fee attached to the child transaction"
+    },
+    {
+      "locale": "es_ES",
+      "original_str": "This channel will be usable after %1 confirmations",
+      "translation": "Este canal sera inutilizable después de %1 confirmaciones"
+    }
+  ]
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_fa_IR.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_fa_IR.json
@@ -1,0 +1,12 @@
+{
+  "generated": "2026-02-19T09:59:01.640502",
+  "locale": "fa_IR",
+  "total_spam": 1,
+  "entries": [
+    {
+      "locale": "fa_IR",
+      "original_str": "  (No FX rate available)",
+      "translation": "متن"
+    }
+  ]
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_fr_FR.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_fr_FR.json
@@ -1,0 +1,12 @@
+{
+  "generated": "2026-02-19T09:59:20.289902",
+  "locale": "fr_FR",
+  "total_spam": 1,
+  "entries": [
+    {
+      "locale": "fr_FR",
+      "original_str": "CLTV expiry",
+      "translation": "CLTV expiration"
+    }
+  ]
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_he_IL.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_he_IL.json
@@ -1,0 +1,6 @@
+{
+  "generated": "2026-02-19T00:12:28.923970",
+  "locale": "he_IL",
+  "total_spam": 0,
+  "entries": []
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_hu_HU.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_hu_HU.json
@@ -1,0 +1,6 @@
+{
+  "generated": "2026-02-19T01:07:10.466669",
+  "locale": "hu_HU",
+  "total_spam": 0,
+  "entries": []
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_hy_AM.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_hy_AM.json
@@ -1,0 +1,6 @@
+{
+  "generated": "2026-02-19T01:13:30.777404",
+  "locale": "hy_AM",
+  "total_spam": 0,
+  "entries": []
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_id_ID.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_id_ID.json
@@ -1,0 +1,57 @@
+{
+  "generated": "2026-02-19T01:35:10.856267",
+  "locale": "id_ID",
+  "total_spam": 10,
+  "entries": [
+    {
+      "locale": "id_ID",
+      "original_str": "Add a cosigner to your multi-sig wallet",
+      "translation": "Tambahkan pengirim barang ke multi-sig wallet milik anda"
+    },
+    {
+      "locale": "id_ID",
+      "original_str": "Address unknown for node:",
+      "translation": "Tambahkan alamat cadangan ke faktur kilat BOLT11."
+    },
+    {
+      "locale": "id_ID",
+      "original_str": "All outputs are non-change is_mine",
+      "translation": "Izinkan pertukaran instan"
+    },
+    {
+      "locale": "id_ID",
+      "original_str": "Cannot create child transaction",
+      "translation": "Transaksi oleh anak kecil tidak bisa di proses."
+    },
+    {
+      "locale": "id_ID",
+      "original_str": "Offline",
+      "translation": "Luring"
+    },
+    {
+      "locale": "id_ID",
+      "original_str": "Remote Node",
+      "translation": "Hapus Node"
+    },
+    {
+      "locale": "id_ID",
+      "original_str": "Save",
+      "translation": "Benih"
+    },
+    {
+      "locale": "id_ID",
+      "original_str": "Your wallet history has been successfully exported.",
+      "translation": "Twoja historia portfela została pomyślnie wyeksportowana."
+    },
+    {
+      "locale": "id_ID",
+      "original_str": "Save",
+      "translation": "Benih"
+    },
+    {
+      "locale": "id_ID",
+      "original_str": "Save",
+      "translation": "Benih"
+    }
+  ]
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_it_IT.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_it_IT.json
@@ -1,0 +1,22 @@
+{
+  "generated": "2026-02-19T02:30:00.279527",
+  "locale": "it_IT",
+  "total_spam": 3,
+  "entries": [
+    {
+      "locale": "it_IT",
+      "original_str": "Cannot have witness v1+ in p2sh",
+      "translation": "Impossibile determinare le tariffe dinamiche, non connesso"
+    },
+    {
+      "locale": "it_IT",
+      "original_str": "[p] - print stored payment order",
+      "translation": "[p] - incolla ordine pagamento archiviato"
+    },
+    {
+      "locale": "it_IT",
+      "original_str": "Transaction is unrelated to this wallet.",
+      "translation": "Transazione non legata a questo portafogli."
+    }
+  ]
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_ja_JP.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_ja_JP.json
@@ -1,0 +1,37 @@
+{
+  "generated": "2026-02-19T03:42:06.315832",
+  "locale": "ja_JP",
+  "total_spam": 6,
+  "entries": [
+    {
+      "locale": "ja_JP",
+      "original_str": "Invalid Public key",
+      "translation": "無効な秘密鍵です"
+    },
+    {
+      "locale": "ja_JP",
+      "original_str": "Not Now",
+      "translation": "Not Now"
+    },
+    {
+      "locale": "ja_JP",
+      "original_str": "Redeem Script",
+      "translation": "文字列に変換"
+    },
+    {
+      "locale": "ja_JP",
+      "original_str": "Distributed by Electrum Technologies GmbH",
+      "translation": "توضیع شده توسط Electrum Technologies GmbH"
+    },
+    {
+      "locale": "ja_JP",
+      "original_str": "Not Now",
+      "translation": "Not Now"
+    },
+    {
+      "locale": "ja_JP",
+      "original_str": "Detect Existing Accounts",
+      "translation": "既存のアカウントを削除"
+    }
+  ]
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_ko_KR.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_ko_KR.json
@@ -1,0 +1,47 @@
+{
+  "generated": "2026-02-19T04:21:09.859496",
+  "locale": "ko_KR",
+  "total_spam": 8,
+  "entries": [
+    {
+      "locale": "ko_KR",
+      "original_str": "Go online to complete wallet creation",
+      "translation": "Go online to complete wallet creation"
+    },
+    {
+      "locale": "ko_KR",
+      "original_str": "Never disclose your seed.",
+      "translation": "당신의 씨앗을 공개하지 마십시오. 웹 사이트에 입력하지 마십시오."
+    },
+    {
+      "locale": "ko_KR",
+      "original_str": "No donation address for this server",
+      "translation": "이메일 주소 알림"
+    },
+    {
+      "locale": "ko_KR",
+      "original_str": "Request force-close",
+      "translation": "リクエストを強制クローズ"
+    },
+    {
+      "locale": "ko_KR",
+      "original_str": "Sign/verify Message",
+      "translation": "로그인"
+    },
+    {
+      "locale": "ko_KR",
+      "original_str": "Success",
+      "translation": "성ㄱ"
+    },
+    {
+      "locale": "ko_KR",
+      "original_str": "Never disclose your seed.",
+      "translation": "당신의 씨앗을 공개하지 마십시오. 웹 사이트에 입력하지 마십시오."
+    },
+    {
+      "locale": "ko_KR",
+      "original_str": "Success",
+      "translation": "성ㄱ"
+    }
+  ]
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_ky_KG.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_ky_KG.json
@@ -1,0 +1,6 @@
+{
+  "generated": "2026-02-19T04:24:22.306769",
+  "locale": "ky_KG",
+  "total_spam": 0,
+  "entries": []
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_lv_LV.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_lv_LV.json
@@ -1,0 +1,17 @@
+{
+  "generated": "2026-02-19T04:51:31.753127",
+  "locale": "lv_LV",
+  "total_spam": 2,
+  "entries": [
+    {
+      "locale": "lv_LV",
+      "original_str": "From",
+      "translation": "No"
+    },
+    {
+      "locale": "lv_LV",
+      "original_str": "Type",
+      "translation": "Tips"
+    }
+  ]
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_nb_NO.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_nb_NO.json
@@ -1,0 +1,82 @@
+{
+  "generated": "2026-02-19T05:03:18.406073",
+  "locale": "nb_NO",
+  "total_spam": 15,
+  "entries": [
+    {
+      "locale": "nb_NO",
+      "original_str": "A suggested fee is automatically added to this field. You may override it. The suggested fee increases with the size of the transaction.",
+      "translation": "A suggested fee is automatically added to this field. You may override it. The suggested fee increases with the size of the transaction."
+    },
+    {
+      "locale": "nb_NO",
+      "original_str": "Number of zeros displayed after the decimal point. For example, if this is set to 2, \\\"1.\\\" will be displayed as \\\"1.00\\\"",
+      "translation": "Number of zeros displayed after the decimal point. For example, if this is set to 2, \\\"1.\\\" will be displayed as \\\"1.00\\\""
+    },
+    {
+      "locale": "nb_NO",
+      "original_str": "Password was updated successfully",
+      "translation": "Password was updated successfully"
+    },
+    {
+      "locale": "nb_NO",
+      "original_str": "Select file to export your private keys to",
+      "translation": "Select file to export your private keys to"
+    },
+    {
+      "locale": "nb_NO",
+      "original_str": "Select which language is used in the GUI (after restart).",
+      "translation": "Select which language is used in the GUI (after restart)."
+    },
+    {
+      "locale": "nb_NO",
+      "original_str": "The amount of fee can be decided freely by the sender. However, transactions with low fees take more time to be processed.",
+      "translation": "The amount of fee can be decided freely by the sender. However, transactions with low fees take more time to be processed."
+    },
+    {
+      "locale": "nb_NO",
+      "original_str": "The description is not sent to the recipient of the funds. It is stored in your wallet file, and displayed in the 'History' tab.",
+      "translation": "The description is not sent to the recipient of the funds. It is stored in your wallet file, and displayed in the 'History' tab."
+    },
+    {
+      "locale": "nb_NO",
+      "original_str": "The following addresses were added",
+      "translation": "The following addresses were added"
+    },
+    {
+      "locale": "nb_NO",
+      "original_str": "The following inputs could not be imported",
+      "translation": "The following inputs could not be imported"
+    },
+    {
+      "locale": "nb_NO",
+      "original_str": "This seed will allow you to recover your wallet in case of computer failure.",
+      "translation": "This seed will allow you to recover your wallet in case of computer failure."
+    },
+    {
+      "locale": "nb_NO",
+      "original_str": "To make sure that you have properly saved your seed, please retype it here.",
+      "translation": "To make sure that you have properly saved your seed, please retype it here."
+    },
+    {
+      "locale": "nb_NO",
+      "original_str": "Warning: The next address will not be recovered automatically if you restore your wallet from seed; you may need to add it manually.\\n\\nThis occurs because you have too many unused addresses in your wallet. To avoid this situation, use the existing addresses first.\\n\\nCreate anyway?",
+      "translation": "Warning: The next address will not be recovered automatically if you restore your wallet from seed; you may need to add it manually.\\n\\nThis occurs because you have too many unused addresses in your wallet. To avoid this situation, use the existing addresses first.\\n\\nCreate anyway?"
+    },
+    {
+      "locale": "nb_NO",
+      "original_str": "Your wallet history has been successfully exported.",
+      "translation": "Your wallet history has been successfully exported."
+    },
+    {
+      "locale": "nb_NO",
+      "original_str": "To make sure that you have properly saved your seed, please retype it here.",
+      "translation": "To make sure that you have properly saved your seed, please retype it here."
+    },
+    {
+      "locale": "nb_NO",
+      "original_str": "This seed will allow you to recover your wallet in case of computer failure.",
+      "translation": "This seed will allow you to recover your wallet in case of computer failure."
+    }
+  ]
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_nl_NL.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_nl_NL.json
@@ -1,0 +1,27 @@
+{
+  "generated": "2026-02-19T06:04:14.362501",
+  "locale": "nl_NL",
+  "total_spam": 4,
+  "entries": [
+    {
+      "locale": "nl_NL",
+      "original_str": "Clear",
+      "translation": "Wissen"
+    },
+    {
+      "locale": "nl_NL",
+      "original_str": "Reporting Bugs",
+      "translation": "Bugs melden"
+    },
+    {
+      "locale": "nl_NL",
+      "original_str": "[Clear]",
+      "translation": "[Wissen]"
+    },
+    {
+      "locale": "nl_NL",
+      "original_str": "tasks",
+      "translation": "taken"
+    }
+  ]
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_pl_PL.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_pl_PL.json
@@ -1,0 +1,12 @@
+{
+  "generated": "2026-02-19T06:20:29.903617",
+  "locale": "pl_PL",
+  "total_spam": 1,
+  "entries": [
+    {
+      "locale": "pl_PL",
+      "original_str": "Banner",
+      "translation": "Transparent"
+    }
+  ]
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_pt_BR.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_pt_BR.json
@@ -1,0 +1,37 @@
+{
+  "generated": "2026-02-19T07:21:49.897794",
+  "locale": "pt_BR",
+  "total_spam": 6,
+  "entries": [
+    {
+      "locale": "pt_BR",
+      "original_str": "Amount too low",
+      "translation": "Quantidade muito pequena"
+    },
+    {
+      "locale": "pt_BR",
+      "original_str": "Could not resolve LNURL",
+      "translation": "Não foi possível resolver LNURL"
+    },
+    {
+      "locale": "pt_BR",
+      "original_str": "This plugin requires installation of additional dependencies.",
+      "translation": "Esta opção só está disponível no Windows"
+    },
+    {
+      "locale": "pt_BR",
+      "original_str": "unknown",
+      "translation": "desconhecido"
+    },
+    {
+      "locale": "pt_BR",
+      "original_str": "Enter the list of private keys to sweep into this wallet",
+      "translation": "Erro: chave(s) privada(s) inválida(s)"
+    },
+    {
+      "locale": "pt_BR",
+      "original_str": "Amount received onchain",
+      "translation": "Quantidade recebida nos canais"
+    }
+  ]
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_pt_PT.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_pt_PT.json
@@ -1,0 +1,12 @@
+{
+  "generated": "2026-02-19T07:43:31.355522",
+  "locale": "pt_PT",
+  "total_spam": 1,
+  "entries": [
+    {
+      "locale": "pt_PT",
+      "original_str": "Block height",
+      "translation": "Peso do bloco"
+    }
+  ]
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_ro_RO.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_ro_RO.json
@@ -1,0 +1,22 @@
+{
+  "generated": "2026-02-19T09:59:28.761538",
+  "locale": "ro_RO",
+  "total_spam": 3,
+  "entries": [
+    {
+      "locale": "ro_RO",
+      "original_str": "Broadcasting transaction...",
+      "translation": "Tranzactie pe lungime de unda mare..."
+    },
+    {
+      "locale": "ro_RO",
+      "original_str": "Seed Type",
+      "translation": "Trimite tip"
+    },
+    {
+      "locale": "ro_RO",
+      "original_str": "Seed Type",
+      "translation": "Trimite tip"
+    }
+  ]
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_ru_RU.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_ru_RU.json
@@ -1,0 +1,47 @@
+{
+  "generated": "2026-02-19T08:33:34.918161",
+  "locale": "ru_RU",
+  "total_spam": 8,
+  "entries": [
+    {
+      "locale": "ru_RU",
+      "original_str": "&Flip horizontally",
+      "translation": "&Flip horizontally"
+    },
+    {
+      "locale": "ru_RU",
+      "original_str": "&New contact",
+      "translation": "&New contact"
+    },
+    {
+      "locale": "ru_RU",
+      "original_str": "- an arbitrary on-chain script, e.g.:",
+      "translation": "- an arbitrary on-chain script, e.g.:"
+    },
+    {
+      "locale": "ru_RU",
+      "original_str": "A CPFP is a transaction that sends an unconfirmed output back to yourself, with a high fee. The goal is to have miners confirm the parent transaction in order to get the fee attached to the child transaction.",
+      "translation": "A CPFP is a transaction that sends an unconfirmed output back to yourself, with a high fee. The goal is to have miners confirm the parent transaction in order to get the fee attached to the child transaction."
+    },
+    {
+      "locale": "ru_RU",
+      "original_str": "A backup does not contain information about your local balance in the channel.",
+      "translation": "A backup does not contain information about your local balance in the channel."
+    },
+    {
+      "locale": "ru_RU",
+      "original_str": "All outputs are non-change is_mine",
+      "translation": "All outputs are non-change is_mine"
+    },
+    {
+      "locale": "ru_RU",
+      "original_str": "At block height: {}",
+      "translation": "At block height: {}"
+    },
+    {
+      "locale": "ru_RU",
+      "original_str": "A CPFP is a transaction that sends an unconfirmed output back to yourself, with a high fee. The goal is to have miners confirm the parent transaction in order to get the fee attached to the child transaction.",
+      "translation": "A CPFP is a transaction that sends an unconfirmed output back to yourself, with a high fee. The goal is to have miners confirm the parent transaction in order to get the fee attached to the child transaction."
+    }
+  ]
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_si_LK.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_si_LK.json
@@ -1,0 +1,6 @@
+{
+  "generated": "2026-02-19T09:59:48.741340",
+  "locale": "si_LK",
+  "total_spam": 0,
+  "entries": []
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_sk_SK.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_sk_SK.json
@@ -1,0 +1,12 @@
+{
+  "generated": "2026-02-19T10:00:13.452040",
+  "locale": "sk_SK",
+  "total_spam": 1,
+  "entries": [
+    {
+      "locale": "sk_SK",
+      "original_str": "watching only",
+      "translation": "len"
+    }
+  ]
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_sl_SI.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_sl_SI.json
@@ -1,0 +1,6 @@
+{
+  "generated": "2026-02-19T10:00:15.540591",
+  "locale": "sl_SI",
+  "total_spam": 0,
+  "entries": []
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_sr_CS.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_sr_CS.json
@@ -1,0 +1,6 @@
+{
+  "generated": "2026-02-19T10:00:15.551284",
+  "locale": "sr_CS",
+  "total_spam": 0,
+  "entries": []
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_summary.txt
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_summary.txt
@@ -1,0 +1,643 @@
+================================================================================
+VANDALISM DETECTION SUMMARY REPORT
+Generated: 2026-02-19T10:02:12.390247
+Total spam entries detected: 164
+================================================================================
+
+
+────────────────────────────────────────
+LOCALE: ar_SA (5 entries)
+────────────────────────────────────────
+
+Original: - an arbitrary on-chain script, e.g.:
+Translation: مشغول
+
+Original: Add to coin control
+Translation: Add to coin control
+
+Original: Cannot start QR scanner, no usable camera found.
+Translation: غير مسموح لك في هذا الجهاز باستخدام كير
+
+Original: Cannot start QR scanner: initialization failed.
+Translation: غير مسموح لك بالقيام  بكير تلف في البيانات
+
+Original: Startup times are instant because it operates in conjunction with high-performance servers that handle the most complicated parts of the Bitcoin system.
+Translation: Startup times are instant because it operates in conjunction with high-performance servers that handle the most complicated parts of the Bitcoin system.
+
+
+────────────────────────────────────────
+LOCALE: az_AZ (2 entries)
+────────────────────────────────────────
+
+Original: Details
+Translation: Detallar
+
+Original: Close Electrum?
+Translation: Electrum bağlanılsın?
+
+
+────────────────────────────────────────
+LOCALE: bg_BG (1 entries)
+────────────────────────────────────────
+
+Original: unknown
+Translation: неизвестен
+
+
+────────────────────────────────────────
+LOCALE: cs_CZ (1 entries)
+────────────────────────────────────────
+
+Original: &Pay to many
+Translation: &Hromadná platba
+
+
+────────────────────────────────────────
+LOCALE: da_DK (3 entries)
+────────────────────────────────────────
+
+Original: Save
+Translation: Gem
+
+Original: Save
+Translation: Gem
+
+Original: Save
+Translation: Gem
+
+
+────────────────────────────────────────
+LOCALE: de_DE (2 entries)
+────────────────────────────────────────
+
+Original: Terms of Use
+Translation: Nutzungsbedingungen
+
+Original: Server settings
+Translation: Servereinstellungen
+
+
+────────────────────────────────────────
+LOCALE: el_GR (1 entries)
+────────────────────────────────────────
+
+Original: Exit Electrum
+Translation: Έξοδος από το Electrum
+
+
+────────────────────────────────────────
+LOCALE: eo_UY (1 entries)
+────────────────────────────────────────
+
+Original: Close
+Translation: Fermi
+
+
+────────────────────────────────────────
+LOCALE: es_ES (18 entries)
+────────────────────────────────────────
+
+Original: A CPFP is a transaction that sends an unconfirmed output back to yourself, with a high fee. The goal is to have miners confirm the parent transaction in order to get the fee attached to the child transaction.
+Translation: A CPFP is a transaction that sends an unconfirmed output back to yourself, with a high fee. The goal is to have miners confirm the parent transaction in order to get the fee attached to the child transaction
+
+Original: Cannot determine dynamic fees, not connected
+Translation: Key: Cannot determine dynamic fees, not connected\n#: electrum/gui/qml/qetxfinalizer.py:431\nFile: messages.pot
+
+Original: Cannot pay less than the amount specified in the invoice
+Translation: Cannot pay less than the amount specified in the invoice
+
+Original: Error parsing Lightning invoice
+Translation: Error al analizar la factura Lightning\n SOLICITUD DE CONTEXTO
+
+Original: Fees are paid by the sender.
+Translation: Las tarifas las paga el remitente.\n SOLICITUD DE CONTEXTO
+
+Original: Integers weights can also be used in conjunction with '!', e.g. set one amount to '2!' and another to '3!' to split your coins 40-60.
+Translation: Los pesos enteros también se pueden usar junto con '!', P. Ej.  establezca una cantidad en '2!'  y otro a '¡3!'  para dividir sus monedas 40-60.\n SOLICITUD DE CONTEXTO
+
+Original: Invoice has unknown status
+Translation: Key: Invoice has unknown status\n#: electrum/gui/qml/qeinvoice.py:295 electrum/gui/qml/qeinvoice.py:312\nFile: messages.pot
+
+Original: Raw
+Translation: Proporciona soporte para la cartera de hardware Safe-T mini
+
+Original: Rebalance your channels in order to increase your sending or receiving capacity
+Translation: Rebalance your channels in order to increase your sending or receiving capacity
+
+Original: The platform QR detection library is not available.
+Translation: The platform QR detection library is not available.
+
+Original: There are still channels that are not fully closed
+Translation: There are still channels that are not fully closed
+
+Original: There are still coins present in this wallet. Really delete?
+Translation: There are still coins present in this wallet. Really delete?
+
+Original: There are still unpaid requests. Really delete?
+Translation: There are still unpaid requests. Really delete?
+
+Original: This is a channel backup.
+Translation: This is a channel backup.
+
+Original: You can use it to request a force close.
+Translation: You can use it to request a force close.
+
+Original: You will be able to pay once the swap is confirmed.
+Translation: You will be able to pay once the swap is confirmed.
+
+Original: A CPFP is a transaction that sends an unconfirmed output back to yourself, with a high fee. The goal is to have miners confirm the parent transaction in order to get the fee attached to the child transaction.
+Translation: A CPFP is a transaction that sends an unconfirmed output back to yourself, with a high fee. The goal is to have miners confirm the parent transaction in order to get the fee attached to the child transaction
+
+Original: This channel will be usable after %1 confirmations
+Translation: Este canal sera inutilizable después de %1 confirmaciones
+
+
+────────────────────────────────────────
+LOCALE: fa_IR (1 entries)
+────────────────────────────────────────
+
+Original:   (No FX rate available)
+Translation: متن
+
+
+────────────────────────────────────────
+LOCALE: fr_FR (1 entries)
+────────────────────────────────────────
+
+Original: CLTV expiry
+Translation: CLTV expiration
+
+
+────────────────────────────────────────
+LOCALE: id_ID (10 entries)
+────────────────────────────────────────
+
+Original: Add a cosigner to your multi-sig wallet
+Translation: Tambahkan pengirim barang ke multi-sig wallet milik anda
+
+Original: Address unknown for node:
+Translation: Tambahkan alamat cadangan ke faktur kilat BOLT11.
+
+Original: All outputs are non-change is_mine
+Translation: Izinkan pertukaran instan
+
+Original: Cannot create child transaction
+Translation: Transaksi oleh anak kecil tidak bisa di proses.
+
+Original: Offline
+Translation: Luring
+
+Original: Remote Node
+Translation: Hapus Node
+
+Original: Save
+Translation: Benih
+
+Original: Your wallet history has been successfully exported.
+Translation: Twoja historia portfela została pomyślnie wyeksportowana.
+
+Original: Save
+Translation: Benih
+
+Original: Save
+Translation: Benih
+
+
+────────────────────────────────────────
+LOCALE: it_IT (3 entries)
+────────────────────────────────────────
+
+Original: Cannot have witness v1+ in p2sh
+Translation: Impossibile determinare le tariffe dinamiche, non connesso
+
+Original: [p] - print stored payment order
+Translation: [p] - incolla ordine pagamento archiviato
+
+Original: Transaction is unrelated to this wallet.
+Translation: Transazione non legata a questo portafogli.
+
+
+────────────────────────────────────────
+LOCALE: ja_JP (6 entries)
+────────────────────────────────────────
+
+Original: Invalid Public key
+Translation: 無効な秘密鍵です
+
+Original: Not Now
+Translation: Not Now
+
+Original: Redeem Script
+Translation: 文字列に変換
+
+Original: Distributed by Electrum Technologies GmbH
+Translation: توضیع شده توسط Electrum Technologies GmbH
+
+Original: Not Now
+Translation: Not Now
+
+Original: Detect Existing Accounts
+Translation: 既存のアカウントを削除
+
+
+────────────────────────────────────────
+LOCALE: ko_KR (8 entries)
+────────────────────────────────────────
+
+Original: Go online to complete wallet creation
+Translation: Go online to complete wallet creation
+
+Original: Never disclose your seed.
+Translation: 당신의 씨앗을 공개하지 마십시오. 웹 사이트에 입력하지 마십시오.
+
+Original: No donation address for this server
+Translation: 이메일 주소 알림
+
+Original: Request force-close
+Translation: リクエストを強制クローズ
+
+Original: Sign/verify Message
+Translation: 로그인
+
+Original: Success
+Translation: 성ㄱ
+
+Original: Never disclose your seed.
+Translation: 당신의 씨앗을 공개하지 마십시오. 웹 사이트에 입력하지 마십시오.
+
+Original: Success
+Translation: 성ㄱ
+
+
+────────────────────────────────────────
+LOCALE: lv_LV (4 entries)
+────────────────────────────────────────
+
+Original: Could not close channel: 
+Translation: Neizdevās atvērt kanālu: 
+
+Original: From
+Translation: No
+
+Original: Outputs
+Translation: Izvadi
+
+Original: Type
+Translation: Tips
+
+
+────────────────────────────────────────
+LOCALE: nb_NO (15 entries)
+────────────────────────────────────────
+
+Original: A suggested fee is automatically added to this field. You may override it. The suggested fee increases with the size of the transaction.
+Translation: A suggested fee is automatically added to this field. You may override it. The suggested fee increases with the size of the transaction.
+
+Original: Number of zeros displayed after the decimal point. For example, if this is set to 2, \"1.\" will be displayed as \"1.00\"
+Translation: Number of zeros displayed after the decimal point. For example, if this is set to 2, \"1.\" will be displayed as \"1.00\"
+
+Original: Password was updated successfully
+Translation: Password was updated successfully
+
+Original: Select file to export your private keys to
+Translation: Select file to export your private keys to
+
+Original: Select which language is used in the GUI (after restart).
+Translation: Select which language is used in the GUI (after restart).
+
+Original: The amount of fee can be decided freely by the sender. However, transactions with low fees take more time to be processed.
+Translation: The amount of fee can be decided freely by the sender. However, transactions with low fees take more time to be processed.
+
+Original: The description is not sent to the recipient of the funds. It is stored in your wallet file, and displayed in the 'History' tab.
+Translation: The description is not sent to the recipient of the funds. It is stored in your wallet file, and displayed in the 'History' tab.
+
+Original: The following addresses were added
+Translation: The following addresses were added
+
+Original: The following inputs could not be imported
+Translation: The following inputs could not be imported
+
+Original: This seed will allow you to recover your wallet in case of computer failure.
+Translation: This seed will allow you to recover your wallet in case of computer failure.
+
+Original: To make sure that you have properly saved your seed, please retype it here.
+Translation: To make sure that you have properly saved your seed, please retype it here.
+
+Original: Warning: The next address will not be recovered automatically if you restore your wallet from seed; you may need to add it manually.\n\nThis occurs because you have too many unused addresses in your wallet. To avoid this situation, use the existing addresses first.\n\nCreate anyway?
+Translation: Warning: The next address will not be recovered automatically if you restore your wallet from seed; you may need to add it manually.\n\nThis occurs because you have too many unused addresses in your wallet. To avoid this situation, use the existing addresses first.\n\nCreate anyway?
+
+Original: Your wallet history has been successfully exported.
+Translation: Your wallet history has been successfully exported.
+
+Original: To make sure that you have properly saved your seed, please retype it here.
+Translation: To make sure that you have properly saved your seed, please retype it here.
+
+Original: This seed will allow you to recover your wallet in case of computer failure.
+Translation: This seed will allow you to recover your wallet in case of computer failure.
+
+
+────────────────────────────────────────
+LOCALE: nl_NL (4 entries)
+────────────────────────────────────────
+
+Original: Clear
+Translation: Wissen
+
+Original: Reporting Bugs
+Translation: Bugs melden
+
+Original: [Clear]
+Translation: [Wissen]
+
+Original: tasks
+Translation: taken
+
+
+────────────────────────────────────────
+LOCALE: pl_PL (1 entries)
+────────────────────────────────────────
+
+Original: Banner
+Translation: Transparent
+
+
+────────────────────────────────────────
+LOCALE: pt_BR (6 entries)
+────────────────────────────────────────
+
+Original: Amount too low
+Translation: Quantidade muito pequena
+
+Original: Could not resolve LNURL
+Translation: Não foi possível resolver LNURL
+
+Original: This plugin requires installation of additional dependencies.
+Translation: Esta opção só está disponível no Windows
+
+Original: unknown
+Translation: desconhecido
+
+Original: Enter the list of private keys to sweep into this wallet
+Translation: Erro: chave(s) privada(s) inválida(s)
+
+Original: Amount received onchain
+Translation: Quantidade recebida nos canais
+
+
+────────────────────────────────────────
+LOCALE: pt_PT (1 entries)
+────────────────────────────────────────
+
+Original: Block height
+Translation: Peso do bloco
+
+
+────────────────────────────────────────
+LOCALE: ro_RO (3 entries)
+────────────────────────────────────────
+
+Original: Broadcasting transaction...
+Translation: Tranzactie pe lungime de unda mare...
+
+Original: Seed Type
+Translation: Trimite tip
+
+Original: Seed Type
+Translation: Trimite tip
+
+
+────────────────────────────────────────
+LOCALE: ru_RU (8 entries)
+────────────────────────────────────────
+
+Original: &Flip horizontally
+Translation: &Flip horizontally
+
+Original: &New contact
+Translation: &New contact
+
+Original: - an arbitrary on-chain script, e.g.:
+Translation: - an arbitrary on-chain script, e.g.:
+
+Original: A CPFP is a transaction that sends an unconfirmed output back to yourself, with a high fee. The goal is to have miners confirm the parent transaction in order to get the fee attached to the child transaction.
+Translation: A CPFP is a transaction that sends an unconfirmed output back to yourself, with a high fee. The goal is to have miners confirm the parent transaction in order to get the fee attached to the child transaction.
+
+Original: A backup does not contain information about your local balance in the channel.
+Translation: A backup does not contain information about your local balance in the channel.
+
+Original: All outputs are non-change is_mine
+Translation: All outputs are non-change is_mine
+
+Original: At block height: {}
+Translation: At block height: {}
+
+Original: A CPFP is a transaction that sends an unconfirmed output back to yourself, with a high fee. The goal is to have miners confirm the parent transaction in order to get the fee attached to the child transaction.
+Translation: A CPFP is a transaction that sends an unconfirmed output back to yourself, with a high fee. The goal is to have miners confirm the parent transaction in order to get the fee attached to the child transaction.
+
+
+────────────────────────────────────────
+LOCALE: sk_SK (1 entries)
+────────────────────────────────────────
+
+Original: watching only
+Translation: len
+
+
+────────────────────────────────────────
+LOCALE: sv_SE (3 entries)
+────────────────────────────────────────
+
+Original: &Plot
+Translation: Rita
+
+Original: &View
+Translation: &Visa
+
+Original: Build Date
+Translation: Versionsdatum
+
+
+────────────────────────────────────────
+LOCALE: th_TH (47 entries)
+────────────────────────────────────────
+
+Original: &Addresses
+Translation: 1Ph4yWX6g7pJk6pgf9fFnQ7fDG8ioCFrLU
+
+Original: &Documentation
+Translation: Ion
+
+Original: &Donate to server
+Translation: Dfu
+
+Original: &Encrypt/decrypt message
+Translation: Fot
+
+Original: &Export
+Translation: Tam
+
+Original: &File
+Translation: Fil
+
+Original: &From file
+Translation: From fil
+
+Original: &From text
+Translation: F. T
+
+Original: &From the blockchain
+Translation: F. Ba
+
+Original: &Help
+Translation: Sh
+
+Original: &Labels
+Translation: La
+
+Original: &Load transaction
+Translation: Lo
+
+Original: &New/Restore
+Translation: Rest
+
+Original: &Official website
+Translation: Ww
+
+Original: &Password
+Translation: Snu all
+
+Original: &Plugins
+Translation: Piu
+
+Original: &Recently open
+Translation: &Recently open
+
+Original: 2. Align your Revealer borderlines to the dashed lines on the top and left.
+Translation: 2. Align your Revealer borderlines to the dashed lines on the top and left.
+
+Original: 4. Type the numbers in the software
+Translation: 4. Type the numbers in the software
+
+Original: A backup is saved automatically when generating a new wallet.
+Translation: A backup is saved automatically when generating a new wallet.
+
+Original: A copy of your wallet file was created in
+Translation: A copy of your wallet file was created in
+
+Original: A few examples
+Translation: A few examples
+
+Original: A library is probably missing.
+Translation: A library is probably missing.
+
+Original: A small fee will be charged on each transaction that uses the remote server.  You may check and modify your billing preferences once the installation is complete.
+Translation: A small fee will be charged on each transaction that uses the remote server.  You may check and modify your billing preferences once the installation is complete.
+
+Original: A suggested fee is automatically added to this field. You may override it. The suggested fee increases with the size of the transaction.
+Translation: A suggested fee is automatically added to this field. You may override it. The suggested fee increases with the size of the transaction.
+
+Original: Accept Word
+Translation: Accept Word
+
+Original: Acquisition price
+Translation: Acquisition price
+
+Original: Add a cosigner to your multi-sig wallet
+Translation: Add a cosigner to your multi-sig wallet
+
+Original: Additional fees
+Translation: Additional fees
+
+Original: Additional {} satoshis are going to be added.
+Translation: Additional {} satoshis are going to be added.
+
+Original: Address is frozen
+Translation: Adresa e blocată
+
+Original: Address not in wallet.
+Translation: Address not in wallet.
+
+Original: Also, dust is not kept as change, but added to the fee.
+Translation: Also, dust is not kept as change, but added to the fee.
+
+Original: Amount for OP_RETURN output must be zero.
+Translation: Amount for OP_RETURN output must be zero.
+
+Original: Amount to be sent
+Translation: Amount to be sent
+
+Original: An uninitialized Digital Bitbox is detected.
+Translation: An uninitialized Digital Bitbox is detected.
+
+Original: An unnamed {}
+Translation: An unnamed {}
+
+Original: Are you SURE you want to wipe the device?\nYour wallet still has bitcoins in it!
+Translation: Are you SURE you want to wipe the device?\nYour wallet still has bitcoins in it!
+
+Original: Are you sure you want to erase the Digital Bitbox?
+Translation: Are you sure you want to erase the Digital Bitbox?
+
+Original: Are you sure you want to proceed?
+Translation: Are you sure you want to proceed?
+
+Original: Are you sure you want to remove this transaction and {} child transactions?
+Translation: Are you sure you want to remove this transaction and {} child transactions?
+
+Original: Are you sure you want to remove this transaction?
+Translation: Are you sure you want to remove this transaction?
+
+Original: Blockchain
+Translation: Address
+
+Original: Broadcasting transaction...
+Translation: Broadcasting transaction...
+
+Original: Child Pays for Parent
+Translation: Child Pays for Parent
+
+Original: Child pays for parent
+Translation: Child Pays for Parent
+
+Original: A few examples
+Translation: A few examples
+
+
+────────────────────────────────────────
+LOCALE: tr_TR (4 entries)
+────────────────────────────────────────
+
+Original: Import
+Translation: Dışa aktar
+
+Original: Use this dialog to change your password.
+Translation: Parola değiştirmek için lütfen e-mail adresini kontrol et
+
+Original: Import
+Translation: Dışa aktar
+
+Original: Import
+Translation: Dışa aktar
+
+
+────────────────────────────────────────
+LOCALE: uk_UA (2 entries)
+────────────────────────────────────────
+
+Original: Script type and Derivation path
+Translation: 31/5000\nТип сценарію і шлях виведення
+
+Original: To create a spending wallet, please enter a master private key (xprv/yprv/zprv).
+Translation: Щоб створити гаманець для оплати, введіть свій відкритий майстер-ключ (xpub/ypub/zpub).
+
+
+────────────────────────────────────────
+LOCALE: zh_TW (2 entries)
+────────────────────────────────────────
+
+Original: 2. Align your Revealer borderlines to the dashed lines on the top and left.
+Translation: 2. Align your Revealer borderlines to the dashed lines on the top and left.
+
+Original: Your wallet history has been successfully exported.
+Translation: 您的錢包歷史記錄已經成功匯入。
+

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_sv_SE.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_sv_SE.json
@@ -1,0 +1,22 @@
+{
+  "generated": "2026-02-19T10:00:27.098022",
+  "locale": "sv_SE",
+  "total_spam": 3,
+  "entries": [
+    {
+      "locale": "sv_SE",
+      "original_str": "&Plot",
+      "translation": "Rita"
+    },
+    {
+      "locale": "sv_SE",
+      "original_str": "&View",
+      "translation": "&Visa"
+    },
+    {
+      "locale": "sv_SE",
+      "original_str": "Build Date",
+      "translation": "Versionsdatum"
+    }
+  ]
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_ta_IN.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_ta_IN.json
@@ -1,0 +1,6 @@
+{
+  "generated": "2026-02-19T10:00:28.716807",
+  "locale": "ta_IN",
+  "total_spam": 0,
+  "entries": []
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_th_TH.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_th_TH.json
@@ -1,0 +1,242 @@
+{
+  "generated": "2026-02-18T16:58:31.989986",
+  "locale": "th_TH",
+  "total_spam": 47,
+  "entries": [
+    {
+      "locale": "th_TH",
+      "original_str": "&Addresses",
+      "translation": "1Ph4yWX6g7pJk6pgf9fFnQ7fDG8ioCFrLU"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "&Documentation",
+      "translation": "Ion"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "&Donate to server",
+      "translation": "Dfu"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "&Encrypt/decrypt message",
+      "translation": "Fot"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "&Export",
+      "translation": "Tam"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "&File",
+      "translation": "Fil"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "&From file",
+      "translation": "From fil"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "&From text",
+      "translation": "F. T"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "&From the blockchain",
+      "translation": "F. Ba"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "&Help",
+      "translation": "Sh"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "&Labels",
+      "translation": "La"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "&Load transaction",
+      "translation": "Lo"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "&New/Restore",
+      "translation": "Rest"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "&Official website",
+      "translation": "Ww"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "&Password",
+      "translation": "Snu all"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "&Plugins",
+      "translation": "Piu"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "&Recently open",
+      "translation": "&Recently open"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "2. Align your Revealer borderlines to the dashed lines on the top and left.",
+      "translation": "2. Align your Revealer borderlines to the dashed lines on the top and left."
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "4. Type the numbers in the software",
+      "translation": "4. Type the numbers in the software"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "A backup is saved automatically when generating a new wallet.",
+      "translation": "A backup is saved automatically when generating a new wallet."
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "A copy of your wallet file was created in",
+      "translation": "A copy of your wallet file was created in"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "A few examples",
+      "translation": "A few examples"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "A library is probably missing.",
+      "translation": "A library is probably missing."
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "A small fee will be charged on each transaction that uses the remote server.  You may check and modify your billing preferences once the installation is complete.",
+      "translation": "A small fee will be charged on each transaction that uses the remote server.  You may check and modify your billing preferences once the installation is complete."
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "A suggested fee is automatically added to this field. You may override it. The suggested fee increases with the size of the transaction.",
+      "translation": "A suggested fee is automatically added to this field. You may override it. The suggested fee increases with the size of the transaction."
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "Accept Word",
+      "translation": "Accept Word"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "Acquisition price",
+      "translation": "Acquisition price"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "Add a cosigner to your multi-sig wallet",
+      "translation": "Add a cosigner to your multi-sig wallet"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "Additional fees",
+      "translation": "Additional fees"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "Additional {} satoshis are going to be added.",
+      "translation": "Additional {} satoshis are going to be added."
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "Address is frozen",
+      "translation": "Adresa e blocată"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "Address not in wallet.",
+      "translation": "Address not in wallet."
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "Also, dust is not kept as change, but added to the fee.",
+      "translation": "Also, dust is not kept as change, but added to the fee."
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "Amount for OP_RETURN output must be zero.",
+      "translation": "Amount for OP_RETURN output must be zero."
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "Amount to be sent",
+      "translation": "Amount to be sent"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "An uninitialized Digital Bitbox is detected.",
+      "translation": "An uninitialized Digital Bitbox is detected."
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "An unnamed {}",
+      "translation": "An unnamed {}"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "Are you SURE you want to wipe the device?\\nYour wallet still has bitcoins in it!",
+      "translation": "Are you SURE you want to wipe the device?\\nYour wallet still has bitcoins in it!"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "Are you sure you want to erase the Digital Bitbox?",
+      "translation": "Are you sure you want to erase the Digital Bitbox?"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "Are you sure you want to proceed?",
+      "translation": "Are you sure you want to proceed?"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "Are you sure you want to remove this transaction and {} child transactions?",
+      "translation": "Are you sure you want to remove this transaction and {} child transactions?"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "Are you sure you want to remove this transaction?",
+      "translation": "Are you sure you want to remove this transaction?"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "Blockchain",
+      "translation": "Address"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "Broadcasting transaction...",
+      "translation": "Broadcasting transaction..."
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "Child Pays for Parent",
+      "translation": "Child Pays for Parent"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "Child pays for parent",
+      "translation": "Child Pays for Parent"
+    },
+    {
+      "locale": "th_TH",
+      "original_str": "A few examples",
+      "translation": "A few examples"
+    }
+  ]
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_tr_TR.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_tr_TR.json
@@ -1,0 +1,27 @@
+{
+  "generated": "2026-02-19T10:00:55.577354",
+  "locale": "tr_TR",
+  "total_spam": 4,
+  "entries": [
+    {
+      "locale": "tr_TR",
+      "original_str": "Import",
+      "translation": "Dışa aktar"
+    },
+    {
+      "locale": "tr_TR",
+      "original_str": "Use this dialog to change your password.",
+      "translation": "Parola değiştirmek için lütfen e-mail adresini kontrol et"
+    },
+    {
+      "locale": "tr_TR",
+      "original_str": "Import",
+      "translation": "Dışa aktar"
+    },
+    {
+      "locale": "tr_TR",
+      "original_str": "Import",
+      "translation": "Dışa aktar"
+    }
+  ]
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_uk_UA.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_uk_UA.json
@@ -1,0 +1,17 @@
+{
+  "generated": "2026-02-19T10:01:21.671322",
+  "locale": "uk_UA",
+  "total_spam": 2,
+  "entries": [
+    {
+      "locale": "uk_UA",
+      "original_str": "Script type and Derivation path",
+      "translation": "31/5000\\nТип сценарію і шлях виведення"
+    },
+    {
+      "locale": "uk_UA",
+      "original_str": "To create a spending wallet, please enter a master private key (xprv/yprv/zprv).",
+      "translation": "Щоб створити гаманець для оплати, введіть свій відкритий майстер-ключ (xpub/ypub/zpub)."
+    }
+  ]
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_vi_VN.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_vi_VN.json
@@ -1,0 +1,6 @@
+{
+  "generated": "2026-02-19T10:01:25.463021",
+  "locale": "vi_VN",
+  "total_spam": 0,
+  "entries": []
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_zh_CN.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_zh_CN.json
@@ -1,0 +1,6 @@
+{
+  "generated": "2026-02-19T10:02:02.125044",
+  "locale": "zh_CN",
+  "total_spam": 0,
+  "entries": []
+}

--- a/llm_vandalism_detection/previous_runs/19022026/vandalism_report_zh_TW.json
+++ b/llm_vandalism_detection/previous_runs/19022026/vandalism_report_zh_TW.json
@@ -1,0 +1,17 @@
+{
+  "generated": "2026-02-19T10:02:12.386498",
+  "locale": "zh_TW",
+  "total_spam": 2,
+  "entries": [
+    {
+      "locale": "zh_TW",
+      "original_str": "2. Align your Revealer borderlines to the dashed lines on the top and left.",
+      "translation": "2. Align your Revealer borderlines to the dashed lines on the top and left."
+    },
+    {
+      "locale": "zh_TW",
+      "original_str": "Your wallet history has been successfully exported.",
+      "translation": "您的錢包歷史記錄已經成功匯入。"
+    }
+  ]
+}

--- a/llm_vandalism_detection/test_vandalism_detection.py
+++ b/llm_vandalism_detection/test_vandalism_detection.py
@@ -1,0 +1,850 @@
+#!/usr/bin/env python3
+"""
+Unit tests for vandalism detection using the real LLM API.
+Tests known vandalism cases from electrum-locale repository.
+
+Run with environment variables, e.g.:
+OPENAI_BASE_URL=https://api.ppq.ai OPENAI_MODEL=google/gemini-3-flash-preview OPENAI_API_KEY=ABC
+"""
+
+import asyncio
+import os
+import sys
+import unittest
+
+import aiohttp
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from llm_vandalism_detection import classify_translation_async, get_concurrency
+
+
+class AsyncVandalismTestCase(unittest.IsolatedAsyncioTestCase):
+    """Base class that provides a shared aiohttp session and semaphore."""
+
+    _session: aiohttp.ClientSession = None
+    _semaphore: asyncio.Semaphore = None
+
+    async def asyncSetUp(self):
+        self._session = aiohttp.ClientSession()
+        self._semaphore = asyncio.Semaphore(get_concurrency())
+
+    async def asyncTearDown(self):
+        await self._session.close()
+
+    async def classify(self, msgid: str, msgstr: str, lang: str) -> str:
+        return await classify_translation_async(
+            self._session, self._semaphore, msgid, msgstr, lang
+        )
+
+
+class TestVandalismDetection(AsyncVandalismTestCase):
+    """
+    Tests that known vandalism cases are correctly classified as Spam.
+    These are real examples from the electrum-locale repository.
+    """
+
+    async def test_fr_FR_redo_thongchai(self):
+        """fr_FR: '&Redo' translated as 'Thongchai' (unrelated name)"""
+        result = await self.classify("&Redo", "Thongchai", "fr_FR")
+        self.assertEqual(result, "Spam", "Unrelated name substitution should be Spam")
+
+    async def test_fr_FR_cancellation_txid(self):
+        """fr_FR: 'Cancellation Transaction ID' translated as actual txid hash"""
+        result = await self.classify(
+            "Cancellation Transaction ID",
+            "edbd3224d120d8304d2194287c4b267707b50b2be46a78409d701327d9d47476\n",
+            "fr_FR"
+        )
+        self.assertEqual(result, "Spam", "Injected transaction hash should be Spam")
+
+    async def test_fa_IR_script_shah2026(self):
+        """fa_IR: '- an arbitrary on-chain script, e.g.:' translated as 'shah2026'"""
+        result = await self.classify(
+            "- an arbitrary on-chain script, e.g.:",
+            "shah2026",
+            "fa_IR"
+        )
+        self.assertEqual(result, "Spam", "Username/handle substitution should be Spam")
+
+    async def test_ro_RO_bitcoin_address_romana(self):
+        """ro_RO: '- a Bitcoin address or BIP21 URI' translated as 'Română română'"""
+        result = await self.classify(
+            "- a Bitcoin address or BIP21 URI",
+            "Română română ",
+            "ro_RO"
+        )
+        self.assertEqual(result, "Spam", "Meaningless language name substitution should be Spam")
+
+    async def test_vi_VN_amount_number(self):
+        """vi_VN: 'Amount to be sent' translated as '10000000000' (8 years old)"""
+        result = await self.classify(
+            "Amount to be sent",
+            "10000000000",
+            "vi_VN"
+        )
+        self.assertEqual(result, "Spam", "Random number substitution should be Spam")
+
+    async def test_cs_CZ_paper_email(self):
+        """cs_CZ: Instructions translated as email address (2 years old)"""
+        result = await self.classify(
+            "1. Place this paper on a flat and well illuminated surface.",
+            "veronikatilke33@seznam.cz",
+            "cs_CZ"
+        )
+        self.assertEqual(result, "Spam", "Email address injection should be Spam")
+
+    async def test_es_ES_amount_received_email(self):
+        """es_ES: 'Amount received: {}' translated as email address"""
+        result = await self.classify(
+            "Amount received: {}",
+            "cmc6686@gmail.com",
+            "es_ES"
+        )
+        self.assertEqual(result, "Spam", "Email address injection should be Spam")
+
+    async def test_fa_IR_undo_username(self):
+        """fa_IR: '&Undo' translated as 'Rastakh8888'"""
+        result = await self.classify(
+            "&Undo",
+            "Rastakh8888\n",
+            "fa_IR"
+        )
+        self.assertEqual(result, "Spam", "Username substitution should be Spam")
+
+    async def test_fr_FR_avoid_spending_btc_address(self):
+        """fr_FR: Address usage warning translated as BTC address (stealing-oriented)"""
+        result = await self.classify(
+            "Avoid spending from used addresses",
+            "bc1qgdl5a90ccznwteha436fn52nekdwuu9ld32n3c",
+            "fr_FR"
+        )
+        self.assertEqual(result, "Spam", "Bitcoin address injection should be Spam")
+
+    async def test_ar_SA_alert_address_btc_address(self):
+        """ar_SA: 'Alert Address' translated as BTC address (stealing-oriented)"""
+        result = await self.classify(
+            "Alert Address",
+            "bc1q393et0s9tv82udvjqfrupyv90s3fqvcfglhrea",
+            "ar_SA"
+        )
+        self.assertEqual(result, "Spam", "Bitcoin address injection should be Spam")
+
+
+class TestVandalismURL(AsyncVandalismTestCase):
+    """Tests for URL injection vandalism."""
+
+    async def test_url_injection_random(self):
+        """URL injected into unrelated translation"""
+        result = await self.classify(
+            "Wallet settings",
+            "https://freebitcoin.com/claim-now",
+            "de_DE"
+        )
+        self.assertEqual(result, "Spam", "Random URL injection should be Spam")
+
+    async def test_url_injection_electrum_update(self):
+        """URL injected into unrelated translation"""
+        result = await self.classify(
+            "Download the update from the Electrum website.",
+            "Lade die Electrum Aktualisierung von electrum.io herunter.",
+            "de_DE"
+        )
+        self.assertEqual(result, "Spam", "Electrum update URL injection should be Spam")
+
+    async def test_telegram_link_injection(self):
+        """Telegram link injected"""
+        result = await self.classify(
+            "Please wait...",
+            "t.me/cryptotrader_group",
+            "ru_RU"
+        )
+        self.assertEqual(result, "Spam", "Telegram link injection should be Spam")
+
+    async def test_phone_number_injection(self):
+        """Phone number injected instead of translation"""
+        result = await self.classify(
+            "Network status",
+            "+1-800-555-0199",
+            "es_ES"
+        )
+        self.assertEqual(result, "Spam", "Phone number injection should be Spam")
+
+
+class TestVandalismPoliticalAdvertising(AsyncVandalismTestCase):
+    """Tests for political/advertising vandalism."""
+
+    async def test_advertising_injection(self):
+        """Advertising text injected"""
+        result = await self.classify(
+            "Confirm transaction",
+            "Buy cheap electronics at bestdeals.com!",
+            "it_IT"
+        )
+        self.assertEqual(result, "Spam", "Advertising injection should be Spam")
+
+    async def test_political_slogan(self):
+        """Political slogan injected"""
+        result = await self.classify(
+            "Balance",
+            "Vote for candidate XYZ 2026",
+            "pt_BR"
+        )
+        self.assertEqual(result, "Spam", "Political slogan injection should be Spam")
+
+
+class TestVandalismGibberish(AsyncVandalismTestCase):
+    """Tests for gibberish/random content."""
+
+    async def test_random_characters(self):
+        """Random character sequence"""
+        result = await self.classify(
+            "Transaction fee",
+            "asdfghjkl qwerty zxcvbnm",
+            "nl_NL"
+        )
+        self.assertEqual(result, "Spam", "Random characters should be Spam")
+
+    async def test_keyboard_mash(self):
+        """Keyboard mashing"""
+        result = await self.classify(
+            "Enter password",
+            "jjjjjjjjjjjjjjjjjjjj",
+            "pl_PL"
+        )
+        self.assertEqual(result, "Spam", "Keyboard mash should be Spam")
+
+    async def test_emoji_spam(self):
+        """Emoji spam instead of translation"""
+        result = await self.classify(
+            "Send Bitcoin",
+            "\U0001f680\U0001f680\U0001f680\U0001f4b0\U0001f4b0\U0001f4b0\U0001f525\U0001f525\U0001f525",
+            "ko_KR"
+        )
+        self.assertEqual(result, "Spam", "Emoji spam should be Spam")
+
+
+class TestVandalismCryptoAddresses(AsyncVandalismTestCase):
+    """Tests for cryptocurrency address injection."""
+
+    async def test_ethereum_address_injection(self):
+        """Ethereum address injected"""
+        result = await self.classify(
+            "Receive",
+            "0x742d35Cc6634C0532925a3b844Bc9e7595f8eA12",
+            "zh_CN"
+        )
+        self.assertEqual(result, "Spam", "Ethereum address injection should be Spam")
+
+    async def test_litecoin_address_injection(self):
+        """Litecoin address injected"""
+        result = await self.classify(
+            "Copy address",
+            "LTC1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+            "tr_TR"
+        )
+        self.assertEqual(result, "Spam", "Litecoin address injection should be Spam")
+
+    async def test_monero_address_injection(self):
+        """Monero address injected"""
+        result = await self.classify(
+            "Wallet backup",
+            "44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A",
+            "sv_SE"
+        )
+        self.assertEqual(result, "Spam", "Monero address injection should be Spam")
+
+
+class TestVandalismSocialMedia(AsyncVandalismTestCase):
+    """Tests for social media handle injection."""
+
+    async def test_twitter_handle_injection(self):
+        """Twitter/X handle injected"""
+        result = await self.classify(
+            "Help",
+            "@follow_me_for_free_btc",
+            "hu_HU"
+        )
+        self.assertEqual(result, "Spam", "Twitter handle injection should be Spam")
+
+    async def test_discord_injection(self):
+        """Discord server link injected"""
+        result = await self.classify(
+            "About",
+            "discord.gg/freecrypto",
+            "cs_CZ"
+        )
+        self.assertEqual(result, "Spam", "Discord link injection should be Spam")
+
+
+class TestVandalismWrongLanguage(AsyncVandalismTestCase):
+    """Tests for completely wrong target language."""
+
+    async def test_wrong_script_cyrillic_for_japanese(self):
+        """Cyrillic text for Japanese target"""
+        result = await self.classify(
+            "Settings",
+            "Привет мир",
+            "ja_JP"
+        )
+        self.assertEqual(result, "Spam", "Cyrillic for Japanese target should be Spam")
+
+    async def test_wrong_script_arabic_for_german(self):
+        """Arabic text for German target"""
+        result = await self.classify(
+            "Confirm",
+            "مرحبا بالعالم",
+            "de_DE"
+        )
+        self.assertEqual(result, "Spam", "Arabic for German target should be Spam")
+
+
+class TestGenuineTranslations(AsyncVandalismTestCase):
+    """
+    Control tests to ensure legitimate translations are not flagged.
+    """
+
+    async def test_genuine_fr_FR(self):
+        """French translation should be Genuine"""
+        result = await self.classify(
+            "Amount to be sent",
+            "Montant à envoyer",
+            "fr_FR"
+        )
+        self.assertEqual(result, "Genuine", "Valid French translation should be Genuine")
+
+    async def test_genuine_de_DE(self):
+        """German translation should be Genuine"""
+        result = await self.classify(
+            "Bitcoin Address",
+            "Bitcoin-Adresse",
+            "de_DE"
+        )
+        self.assertEqual(result, "Genuine", "Valid German translation should be Genuine")
+
+    async def test_genuine_ja_JP(self):
+        """Japanese translation should be Genuine"""
+        result = await self.classify(
+            "Send",
+            "送金",
+            "ja_JP"
+        )
+        self.assertEqual(result, "Genuine", "Valid Japanese translation should be Genuine")
+
+    async def test_genuine_technical_terms_preserved(self):
+        """Technical terms left untranslated should be Genuine"""
+        result = await self.classify(
+            "BIP21 URI",
+            "URI BIP21",
+            "fr_FR"
+        )
+        self.assertEqual(result, "Genuine", "Technical terms preservation should be Genuine")
+
+    async def test_genuine_zh_CN(self):
+        """Chinese simplified translation should be Genuine"""
+        result = await self.classify(
+            "Wallet",
+            "钱包",
+            "zh_CN"
+        )
+        self.assertEqual(result, "Genuine", "Valid Chinese translation should be Genuine")
+
+    async def test_genuine_ar_SA(self):
+        """Arabic translation should be Genuine"""
+        result = await self.classify(
+            "Password",
+            "كلمة المرور",
+            "ar_SA"
+        )
+        self.assertEqual(result, "Genuine", "Valid Arabic translation should be Genuine")
+
+    async def test_genuine_ru_RU(self):
+        """Russian translation should be Genuine"""
+        result = await self.classify(
+            "Transaction",
+            "Транзакция",
+            "ru_RU"
+        )
+        self.assertEqual(result, "Genuine", "Valid Russian translation should be Genuine")
+
+    async def test_genuine_ko_KR(self):
+        """Korean translation should be Genuine"""
+        result = await self.classify(
+            "Confirm",
+            "확인",
+            "ko_KR"
+        )
+        self.assertEqual(result, "Genuine", "Valid Korean translation should be Genuine")
+
+    async def test_genuine_pt_BR(self):
+        """Portuguese (Brazil) translation should be Genuine"""
+        result = await self.classify(
+            "Receive",
+            "Receber",
+            "pt_BR"
+        )
+        self.assertEqual(result, "Genuine", "Valid Portuguese translation should be Genuine")
+
+    async def test_genuine_placeholder_preserved(self):
+        """Placeholders correctly preserved"""
+        result = await self.classify(
+            "Amount received: {}",
+            "Montant reçu : {}",
+            "fr_FR"
+        )
+        self.assertEqual(result, "Genuine", "Placeholder preservation should be Genuine")
+
+    async def test_genuine_qt_markup_preserved(self):
+        """Qt markup preserved in translation"""
+        result = await self.classify(
+            "&File",
+            "&Fichier",
+            "fr_FR"
+        )
+        self.assertEqual(result, "Genuine", "Qt markup preservation should be Genuine")
+
+    async def test_genuine_html_markup(self):
+        """HTML markup in translation"""
+        result = await self.classify(
+            "<b>Warning:</b> This action cannot be undone",
+            "<b>Avertissement :</b> Cette action ne peut pas être annulée",
+            "fr_FR"
+        )
+        self.assertEqual(result, "Genuine", "HTML markup translation should be Genuine")
+
+    async def test_genuine_technical_domain_terms(self):
+        """Domain-specific technical terms"""
+        result = await self.classify(
+            "CPFP transaction",
+            "Transaction CPFP",
+            "fr_FR"
+        )
+        self.assertEqual(result, "Genuine", "Technical domain terms should be Genuine")
+
+    async def test_genuine_bitcoin_terminology(self):
+        """Bitcoin-specific terminology preserved"""
+        result = await self.classify(
+            "Satoshis per byte",
+            "Satoshis par octet",
+            "fr_FR"
+        )
+        self.assertEqual(result, "Genuine", "Bitcoin terminology should be Genuine")
+
+    async def test_genuine_long_instruction_text(self):
+        """Longer instructional text"""
+        result = await self.classify(
+            "A CPFP is a transaction that sends an unconfirmed output back to yourself, with a high fee.",
+            "Un CPFP est une transaction qui vous renvoie une sortie non confirmée, avec des frais élevés.",
+            "fr_FR"
+        )
+        self.assertEqual(result, "Genuine", "Long translated text should be Genuine")
+
+    async def test_genuine_idiomatic_translation(self):
+        """Idiomatic translation that differs from literal"""
+        result = await self.classify(
+            "Got it",
+            "D'accord",
+            "fr_FR"
+        )
+        self.assertEqual(result, "Genuine", "Idiomatic translations should be Genuine")
+
+
+class TestEdgeCases(AsyncVandalismTestCase):
+    """Tests for edge cases and boundary conditions."""
+
+    async def test_partial_translation_genuine(self):
+        """Partial translation should still be Genuine"""
+        result = await self.classify(
+            "Bitcoin wallet backup",
+            "Bitcoin wallet サックアップ",
+            "ja_JP"
+        )
+        self.assertEqual(result, "Genuine", "Partial translation should be Genuine")
+
+    async def test_abbreviation_preserved(self):
+        """Common abbreviation preserved"""
+        result = await self.classify(
+            "BTC",
+            "BTC",
+            "es_ES"
+        )
+        self.assertEqual(result, "Genuine", "Preserved abbreviation should be Genuine")
+
+    async def test_number_format_different(self):
+        """Number formatting can vary by locale"""
+        result = await self.classify(
+            "1,000.00 BTC",
+            "1.000,00 BTC",
+            "de_DE"
+        )
+        self.assertEqual(result, "Genuine", "Locale-specific number format should be Genuine")
+
+
+class TestVandalismSeedPhraseInjection(AsyncVandalismTestCase):
+    """Tests for seed phrase / private key injection attempts."""
+
+    async def test_seed_phrase_injection(self):
+        """Seed phrase words injected as translation"""
+        result = await self.classify(
+            "Enter your password",
+            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+            "de_DE"
+        )
+        self.assertEqual(result, "Spam", "Seed phrase injection should be Spam")
+
+    async def test_private_key_wif_injection(self):
+        """WIF private key injected"""
+        result = await self.classify(
+            "Backup wallet",
+            "5HueCGU8rMjxEXxiPuD5BDku4MkFqeZyd4dZ1jvhTVqvbTLvyTJ",
+            "fr_FR"
+        )
+        self.assertEqual(result, "Spam", "Private key injection should be Spam")
+
+    async def test_hex_private_key_injection(self):
+        """Hex private key injected"""
+        result = await self.classify(
+            "Sign message",
+            "e8f32e723decf4051aefac8e2c93c9c5b214313817cdb01a1494b917c8436b35",
+            "it_IT"
+        )
+        self.assertEqual(result, "Spam", "Hex key injection should be Spam")
+
+
+class TestVandalismOffensiveContent(AsyncVandalismTestCase):
+    """Tests for offensive / inappropriate content."""
+
+    async def test_profanity_injection(self):
+        """Profanity injected instead of translation"""
+        result = await self.classify(
+            "Loading wallet...",
+            "Fuck this stupid app",
+            "en_GB"
+        )
+        self.assertEqual(result, "Spam", "Profanity injection should be Spam")
+
+    async def test_insult_injection(self):
+        """Personal insult injected"""
+        result = await self.classify(
+            "Transaction complete",
+            "You are an idiot for using this",
+            "es_ES"
+        )
+        self.assertEqual(result, "Spam", "Insult injection should be Spam")
+
+
+class TestVandalismPromotionalContent(AsyncVandalismTestCase):
+    """Tests for promotional / marketing spam."""
+
+    async def test_casino_promotion(self):
+        """Online casino promotion injected"""
+        result = await self.classify(
+            "Fee estimation",
+            "Win big at CryptoSlots Casino! Deposit now!",
+            "pt_BR"
+        )
+        self.assertEqual(result, "Spam", "Casino promotion should be Spam")
+
+    async def test_investment_scam(self):
+        """Investment scam text injected"""
+        result = await self.classify(
+            "Verify signature",
+            "Double your Bitcoin in 24 hours! Send to this address!",
+            "ru_RU"
+        )
+        self.assertEqual(result, "Spam", "Investment scam should be Spam")
+
+    async def test_job_offer_spam(self):
+        """Fake job offer spam"""
+        result = await self.classify(
+            "Address type",
+            "Work from home $5000/week contact john@gmail.com",
+            "nl_NL"
+        )
+        self.assertEqual(result, "Spam", "Job offer spam should be Spam")
+
+
+class TestVandalismIdentityInjection(AsyncVandalismTestCase):
+    """Tests for personal identity / name injection."""
+
+    async def test_random_person_name(self):
+        """Random person name injected"""
+        result = await self.classify(
+            "&Copy",
+            "John Smith",
+            "zh_CN"
+        )
+        self.assertEqual(result, "Spam", "Random name injection should be Spam")
+
+    async def test_company_name_injection(self):
+        """Unrelated company name injected"""
+        result = await self.classify(
+            "Block height",
+            "Microsoft Corporation",
+            "ja_JP"
+        )
+        self.assertEqual(result, "Spam", "Company name injection should be Spam")
+
+    async def test_gamer_tag_injection(self):
+        """Gaming handle / gamer tag injected"""
+        result = await self.classify(
+            "Sweep all",
+            "xXx_Pr0Gamer_420_xXx",
+            "ko_KR"
+        )
+        self.assertEqual(result, "Spam", "Gamer tag injection should be Spam")
+
+
+class TestVandalismDateTimeInjection(AsyncVandalismTestCase):
+    """Tests for arbitrary date/time injection."""
+
+    async def test_random_date_injection(self):
+        """Random date injected"""
+        result = await self.classify(
+            "Confirm payment",
+            "2025-03-15 14:32:00",
+            "sv_SE"
+        )
+        self.assertEqual(result, "Spam", "Random date injection should be Spam")
+
+    async def test_countdown_injection(self):
+        """Countdown text injected"""
+        result = await self.classify(
+            "Sign transaction",
+            "Only 3 days left until the big event!",
+            "da_DK"
+        )
+        self.assertEqual(result, "Spam", "Countdown injection should be Spam")
+
+
+class TestVandalismCodeInjection(AsyncVandalismTestCase):
+    """Tests for code/script injection attempts."""
+
+    async def test_javascript_injection(self):
+        """JavaScript code injected"""
+        result = await self.classify(
+            "Click to continue",
+            "<script>alert('Klicken um fortzufahren')</script>",
+            "de_DE"
+        )
+        self.assertEqual(result, "Spam", "JavaScript injection should be Spam")
+
+    async def test_qt_markup_injection(self):
+        """Qt markup injected"""
+        result = await self.classify(
+            "Click to continue",
+            "<a href='https://electrum.io/landing'>Klicken um fortzufahren</a>",
+            "de_DE"
+        )
+        self.assertEqual(result, "Spam", "Qt markup injection should be Spam")
+
+    async def test_sql_injection_attempt(self):
+        """SQL injection attempt"""
+        result = await self.classify(
+            "Search",
+            "'; DROP TABLE wallets; --",
+            "pl_PL"
+        )
+        self.assertEqual(result, "Spam", "SQL injection should be Spam")
+
+
+class TestGenuineComplexTranslations(AsyncVandalismTestCase):
+    """Tests for complex genuine translations that might be edge cases."""
+
+    async def test_genuine_with_numbers(self):
+        """Translation containing legitimate numbers"""
+        result = await self.classify(
+            "Requires 2 confirmations",
+            "Requiert 2 confirmations",
+            "fr_FR"
+        )
+        self.assertEqual(result, "Genuine", "Translation with numbers should be Genuine")
+
+    async def test_genuine_plural_form(self):
+        """Plural form translation"""
+        result = await self.classify(
+            "{} confirmations",
+            "{} confirmations",
+            "fr_FR"
+        )
+        self.assertEqual(result, "Genuine", "Plural form should be Genuine")
+
+    async def test_genuine_empty_placeholder(self):
+        """String that is just a placeholder"""
+        result = await self.classify(
+            "%s",
+            "%s",
+            "de_DE"
+        )
+        self.assertEqual(result, "Genuine", "Placeholder-only string should be Genuine")
+
+    async def test_genuine_mixed_scripts_thai(self):
+        """Thai translation with English technical terms"""
+        result = await self.classify(
+            "Bitcoin wallet",
+            "กระเป๋า Bitcoin",
+            "th_TH"
+        )
+        self.assertEqual(result, "Genuine", "Thai translation should be Genuine")
+
+    async def test_genuine_mixed_scripts_hebrew(self):
+        """Hebrew translation with mixed direction"""
+        result = await self.classify(
+            "Send BTC",
+            "שלח BTC",
+            "he_IL"
+        )
+        self.assertEqual(result, "Genuine", "Hebrew translation should be Genuine")
+
+    async def test_genuine_mixed_scripts_hindi(self):
+        """Hindi translation"""
+        result = await self.classify(
+            "Wallet",
+            "वॉलेट",
+            "hi_IN"
+        )
+        self.assertEqual(result, "Genuine", "Hindi translation should be Genuine")
+
+    async def test_genuine_transliteration(self):
+        """Transliteration is acceptable"""
+        result = await self.classify(
+            "Bitcoin",
+            "比特币",
+            "zh_CN"
+        )
+        self.assertEqual(result, "Genuine", "Transliteration should be Genuine")
+
+    async def test_genuine_complex_qt_markup(self):
+        """Complex Qt markup with multiple elements"""
+        result = await self.classify(
+            "&Edit | &Delete | &Copy",
+            "&Éditer | &Supprimer | &Copier",
+            "fr_FR"
+        )
+        self.assertEqual(result, "Genuine", "Complex Qt markup should be Genuine")
+
+    async def test_genuine_multiple_placeholders(self):
+        """Multiple placeholders in string"""
+        result = await self.classify(
+            "Sent {amount} to {address}",
+            "Envoyé {amount} à {address}",
+            "fr_FR"
+        )
+        self.assertEqual(result, "Genuine", "Multiple placeholders should be Genuine")
+
+    async def test_genuine_error_message(self):
+        """Error message translation"""
+        result = await self.classify(
+            "Error: Insufficient funds",
+            "Erreur : Fonds insuffisants",
+            "fr_FR"
+        )
+        self.assertEqual(result, "Genuine", "Error message translation should be Genuine")
+
+    async def test_genuine_question_text(self):
+        """Question text translation"""
+        result = await self.classify(
+            "Are you sure you want to delete this wallet?",
+            "Êtes-vous sûr de vouloir supprimer ce portefeuille ?",
+            "fr_FR"
+        )
+        self.assertEqual(result, "Genuine", "Question translation should be Genuine")
+
+    async def test_genuine_url_in_original(self):
+        """URL present in original should be preserved"""
+        result = await self.classify(
+            "Visit https://electrum.org for more information",
+            "Visitez https://electrum.org pour plus d'informations",
+            "fr_FR"
+        )
+        self.assertEqual(result, "Genuine", "Preserved URL should be Genuine")
+
+
+class TestVandalismMoreCryptoScams(AsyncVandalismTestCase):
+    """Additional tests for crypto-specific scams."""
+
+    async def test_fake_support_message(self):
+        """Fake support message injection"""
+        result = await self.classify(
+            "Help",
+            "For support contact admin@electrum-support.com",
+            "de_DE"
+        )
+        self.assertEqual(result, "Spam", "Fake support message should be Spam")
+
+    async def test_airdrop_scam(self):
+        """Airdrop scam injection"""
+        result = await self.classify(
+            "Receive address",
+            "Claim your free 1 BTC airdrop now!",
+            "es_ES"
+        )
+        self.assertEqual(result, "Spam", "Airdrop scam should be Spam")
+
+    async def test_exchange_promotion(self):
+        """Exchange promotion injection"""
+        result = await self.classify(
+            "Exchange rate",
+            "Trade on BinanceScam exchange with 0% fees!",
+            "zh_TW"
+        )
+        self.assertEqual(result, "Spam", "Exchange promotion should be Spam")
+
+
+class TestVandalismSpecialCharacters(AsyncVandalismTestCase):
+    """Tests for special character abuse."""
+
+    async def test_zalgo_text(self):
+        """Zalgo/corrupted text injection"""
+        result = await self.classify(
+            "Balance",
+            "B̷̢̺̈́ą̸̛l̷̰͑a̸̱͝n̵̗̏c̸̣̊e̷̤̔",
+            "en_US"
+        )
+        self.assertEqual(result, "Spam", "Zalgo text should be Spam")
+
+    async def test_invisible_characters(self):
+        """Zero-width characters abuse"""
+        result = await self.classify(
+            "Send",
+            "S\u200be\u200bn\u200bd\u200b\u200b\u200bClick here for free BTC",
+            "fr_FR"
+        )
+        self.assertEqual(result, "Spam", "Hidden text injection should be Spam")
+
+    async def test_excessive_punctuation(self):
+        """Excessive punctuation spam"""
+        result = await self.classify(
+            "Warning!",
+            "!!!!!!!!!!!!!!!!!!!!",
+            "it_IT"
+        )
+        self.assertEqual(result, "Spam", "Excessive punctuation should be Spam")
+
+
+class TestVandalismIPAddresses(AsyncVandalismTestCase):
+    """Tests for IP address injection."""
+
+    async def test_ipv4_injection(self):
+        """IPv4 address injected"""
+        result = await self.classify(
+            "Server settings",
+            "192.168.1.100:8080",
+            "ru_RU"
+        )
+        self.assertEqual(result, "Spam", "IPv4 injection should be Spam")
+
+    async def test_ipv6_injection(self):
+        """IPv6 address injected"""
+        result = await self.classify(
+            "Connect to node",
+            "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+            "ja_JP"
+        )
+        self.assertEqual(result, "Spam", "IPv6 injection should be Spam")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)
+


### PR DESCRIPTION
Adds a script utilizing a LLM to check .po translation files for vandalized translations.

I think it is reasonably reliable and seems to tend more on the false positive side.

Using `google/gemini-3-flash-preview` it costs roughly ~0.02 usd cent per translation (on ppq.ai).
We have ~184660 translations, so running this script once through the whole repo would
cost ~36$ using `gemini-3-flash-preview`.
This should hopefully allow us to detect most of the vandalism that has happened over time.

The script itself and the unittests were mostly written by an LLM as well, i reviewed (and tested) them and they seem to do the job.

For the future we could modify the script to run it in the CI and check only the diff of new translations if it turns out to be accurate enough.


**Edit**:

> ~We have 184660 translations, so running this script once through the whole repo would cost 36$ using `gemini-3-flash-preview`.~

The sum of ~184660 translations i used for the calculation above is the sum of all words from the crowdin UI, though what actually matters is the count of *strings*, which is much lower ~42k, resulting in a lower cost of only roughly ~9$ to scan the whole translation set.