### PR TITLE
ci: change on: pull_request -> pull_request_target

### DIFF
--- a/.github/workflows/proofreader.yml
+++ b/.github/workflows/proofreader.yml
@@ -1,7 +1,8 @@
 name: LLM Translation Proofreader
 
 on:
-  pull_request:
+  # danger! PRs have access to env secrets. Only safe as we manually approve CI runs for external contributors.
+  pull_request_target:
     branches: [master]
   workflow_dispatch:
 


### PR DESCRIPTION
This allows environment secrets to be passed into CI runs initiated from forks.
At the same time CI runs from external contributors need to be restricted to approval only so pull requests from untrusted authors cannot run before members of spesmilo have reviewed that it doesn't try to fiddle with the CI config.