### PR TITLE
ci: proofreader: check out pull request branch head

### DIFF
--- a/.github/workflows/proofreader.yml
+++ b/.github/workflows/proofreader.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
The switch from on: pull_request to on: pull_request_target changed the checkout branch from the head of the branch to the head of the target (master), so the diff was empty.