### PR TITLE
ci: proofreader: remove environment namespace

### DIFF
--- a/.github/workflows/proofreader.yml
+++ b/.github/workflows/proofreader.yml
@@ -14,7 +14,6 @@ jobs:
   proofreader:
     name: LLM Translation Proofreader
     runs-on: ubuntu-24.04
-    environment: proofreader
     env:
       OPENAI_BASE_URL: "https://api.ppq.ai"
       OPENAI_MODEL: "google/gemini-3-flash-preview"


### PR DESCRIPTION
Remove the `environment: proofreader` tag from the proofreader workflow so it is ran as workflow and not as deployment(?)